### PR TITLE
feature: reduce go version requirement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,9 @@ module go-web-test
 
 go 1.23
 
-toolchain go1.24.0
+toolchain go1.24.1
+
+// toolchain go1.24.0
 
 require (
 	github.com/PuerkitoBio/goquery v1.10.2


### PR DESCRIPTION
* Moved to require at least go 1.16